### PR TITLE
feat: habilitar Actuator e Prometheus

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,10 @@
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-oauth2-jose</artifactId>
         </dependency>
-
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
         <dependency>
             <groupId>io.jsonwebtoken</groupId>
             <artifactId>jjwt-api</artifactId>

--- a/src/main/java/br/dev/jstec/tyginvestiment/config/security/SecurityConfig.java
+++ b/src/main/java/br/dev/jstec/tyginvestiment/config/security/SecurityConfig.java
@@ -40,6 +40,7 @@ public class SecurityConfig {
                 .csrf(CsrfConfigurer::disable)
                 .authorizeHttpRequests(authorize -> authorize
                         .requestMatchers("/users/new").permitAll()
+                        .requestMatchers("/actuator/**").permitAll()
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/swagger-resources/**", "/swagger-ui.html", "/auth/**", "/actuator/**").permitAll()
                         .anyRequest().authenticated())
                 .addFilter(jwtLoginFilter)

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -34,13 +34,21 @@ server:
     context-path: /tyg-investments
 
 
-#management:
-#  endpoints:
-#    web:
-#      exposure:
-#        include: health,info,metrics
-#
-#
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info,metrics
+      cors:
+        allowed-origins: http://localhost:3000
+  endpoint:
+    health:
+      show-details: always
+  prometheus:
+    metrics:
+      export:
+        enabled: true
+
 
 logging:
   level:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -51,7 +51,13 @@ management:
         include: health,info,metrics
       cors:
         allowed-origins: http://localhost:3000
-
+  endpoint:
+    health:
+      show-details: always
+  prometheus:
+    metrics:
+      export:
+        enabled: true
 
 
 


### PR DESCRIPTION
- Habilitar endpoints do Actuator e configurar CORS no application-prod.yaml e application.yaml
- Adicionar dependência do Spring Boot Actuator no pom.xml
- Permitir acesso aos endpoints do Actuator em SecurityConfig.java