### PR TITLE
Set default for JWT secret key

### DIFF
--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -71,7 +71,7 @@ logging:
 app:
   jwt:
     secret:
-      key: ${JWT_SECRET_KEY}
+      key: ${JWT_SECRET_KEY:secret-key}
   config:
     currency-base: BRL
     decimal-places: 4

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -74,7 +74,7 @@ logging:
 app:
   jwt:
     secret:
-      key: ${JWT_SECRET_KEY}
+      key: ${JWT_SECRET_KEY:secret-key}
   config:
     currency-base: BRL
     decimal-places: 4


### PR DESCRIPTION
Updated `application-prod.yaml` and `application.yaml` to provide a default value for the JWT secret key. This ensures the application has a fallback key if the environment variable `JWT_SECRET_KEY` is not set.